### PR TITLE
add tags to display under scenario and feature

### DIFF
--- a/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
+++ b/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
@@ -29,12 +29,18 @@ internal static class GherkinDocumentExtensions
                 case Scenario scenario:
                     var gurkaScenario = scenario.ToGurkaScenario();
                     gurkaFeature.Scenarios.Add(gurkaScenario);
-                    // Add scenario tags to feature tags
-                    featureTags.AddRange(gurkaScenario.Tags);
+                    if (gurkaScenario.Tags.Contains("@ignore"))
+                    {
+                        featureIgnored = true;
+                    }
                     break;
                 case Rule rule:
                     var gurkaRule = rule.ToGurkaRule();
                     gurkaFeature.Rules.Add(gurkaRule);
+                    if (gurkaRule.Tags.Contains("@ignore") || gurkaRule.Scenarios.Any(s => s.Tags.Contains("@ignore")))
+                    {
+                        featureIgnored = true;
+                    }
                     break;
             }
         }
@@ -57,6 +63,9 @@ internal static class GherkinDocumentExtensions
             Name = rule.Name,
             Description = rule.Description?.TrimStart() ?? string.Empty
         };
+
+        var ruleTags = rule.Tags?.Select(tag => tag.Name).ToList() ?? new List<string>();
+        gurkaRule.Tags = ruleTags;
 
         foreach (var ruleChild in rule.Children)
         {

--- a/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
+++ b/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
@@ -16,8 +16,8 @@ internal static class GherkinDocumentExtensions
             Description = gherkinFeature.Description
         };
 
-        var featureIgnored = gherkinFeature.Tags?.Any(tag => tag.Name == "@ignore") ?? false;
         var featureTags = gherkinFeature.Tags?.Select(tag => tag.Name).ToList() ?? new List<string>();
+        var featureIgnored = featureTags.Any(tag => tag == "@ignore");
 
         foreach (var featureChild in gherkinFeature.Children)
         {
@@ -144,18 +144,21 @@ internal static class GherkinDocumentExtensions
 
         gurkaFeature.Rules.ForEach(rule =>
         {
-            rule.Status = Status.NotImplemented;
-            if (rule.Background != null)
+            if (rule.Tags.Contains("@ignore") || rule.Scenarios.Any(s => s.Tags.Contains("@ignore")))
             {
-                rule.Background.Status = Status.NotImplemented;
-                rule.Background.Steps.ForEach(step => step.Status = Status.NotImplemented);
-            }
+                rule.Status = Status.NotImplemented;
+                if (rule.Background != null)
+                {
+                    rule.Background.Status = Status.NotImplemented;
+                    rule.Background.Steps.ForEach(step => step.Status = Status.NotImplemented);
+                }
 
-            rule.Scenarios.ForEach(scenario =>
-            {
-                scenario.Status = Status.NotImplemented;
-                scenario.Steps.ForEach(step => step.Status = Status.NotImplemented);
-            });
+                rule.Scenarios.ForEach(scenario =>
+                {
+                    scenario.Status = Status.NotImplemented;
+                    scenario.Steps.ForEach(step => step.Status = Status.NotImplemented);
+                });
+            }
         });
     }
 }

--- a/source/VizGurka/Pages/Features/Features.cshtml
+++ b/source/VizGurka/Pages/Features/Features.cshtml
@@ -177,6 +177,28 @@
                         <div class="container_scenario_rule">
                             <hr />
                             <h3 class="scenario_rule_name" id="@rule.Name-rule">Rule: @rule.Name</h3>
+                            @if (rule.Tags.Any())
+                            {
+                                <ul class="tag_list scenario_tags">
+                                    @foreach (var tag in rule.Tags)
+                                    {
+                                        var sanitizedTag = tag.Length > 1 ? tag.Substring(1) : tag;
+                                        var casedTag = char.ToUpper(sanitizedTag[0]) + sanitizedTag.Substring(1);
+                                        if (sanitizedTag == "ignore")
+                                        {
+                                            <li class="tag ignore">@casedTag</li>
+                                        }
+                                        else if (sanitizedTag == "smoke")
+                                        {
+                                            <li class="tag smoke">@casedTag</li>
+                                        }
+                                        else
+                                        {
+                                            <li class="tag">@casedTag</li>
+                                        }
+                                    }
+                                </ul>
+                            }
                             <div class="scenario_rule_description" id="scenario_rule_description">
                                 @Model.MarkdownStringToHtml(rule.Description)</div>
                         </div>
@@ -189,6 +211,28 @@
                                         src="~/icons/@(IconHelper.GetStatusIcon(scenario.Status)).svg" alt="status icon" />
                                     @scenario.Name
                                 </h2>
+                                if (scenario.Tags.Any())
+                                {
+                                    <ul class="tag_list scenario_tags">
+                                        @foreach (var tag in scenario.Tags)
+                                        {
+                                            var sanitizedTag = tag.Length > 1 ? tag.Substring(1) : tag;
+                                            var casedTag = char.ToUpper(sanitizedTag[0]) + sanitizedTag.Substring(1);
+                                            if (sanitizedTag == "ignore")
+                                            {
+                                                <li class="tag ignore">@casedTag</li>
+                                            }
+                                            else if (sanitizedTag == "smoke")
+                                            {
+                                                <li class="tag smoke">@casedTag</li>
+                                            }
+                                            else
+                                            {
+                                                <li class="tag">@casedTag</li>
+                                            }
+                                        }
+                                    </ul>
+                                }
                                 <h3 class="container_scenario_duration"><strong>Scenario duration:</strong> @scenario.TestDuration</h3>
                                 @foreach (var step in scenario.Steps)
                                 {

--- a/source/VizGurka/Pages/Features/Features.cshtml
+++ b/source/VizGurka/Pages/Features/Features.cshtml
@@ -105,6 +105,25 @@
                             alt="status icon" />
                         @Model.SelectedFeature.Name
                     </h1>
+                    <ul class="tag_list">
+                        @foreach (var tag in Model.SelectedFeature.Tags)
+                        {
+                            var sanitizedTag = tag.Length > 1 ? tag.Substring(1) : tag;
+                            var casedTag = char.ToUpper(sanitizedTag[0]) + sanitizedTag.Substring(1);
+                            if (sanitizedTag == "ignore")
+                            {
+                                <li class="tag ignore">@casedTag</li>
+                            }
+                            else if (sanitizedTag == "smoke")
+                            {
+                                <li class="tag smoke">@casedTag</li>
+                            }
+                            else
+                            {
+                                <li class="tag">@casedTag</li>
+                            }
+                        }
+                    </ul>
                     <p class="content_container_duration">Test Duration: @Model.SelectedFeature.TestDuration</p>
                 </div>
                 <h2 class="container_scenarios_title">Scenarios</h2>
@@ -117,6 +136,28 @@
                                 src="~/icons/@(IconHelper.GetStatusIcon(scenario.Status)).svg" alt="status icon" />
                             @scenario.Name
                         </h2>
+                        if (scenario.Tags.Any())
+                        {
+                            <ul class="tag_list scenario_tags">
+                                @foreach (var tag in scenario.Tags)
+                                {
+                                    var sanitizedTag = tag.Length > 1 ? tag.Substring(1) : tag;
+                                    var casedTag = char.ToUpper(sanitizedTag[0]) + sanitizedTag.Substring(1);
+                                    if (sanitizedTag == "ignore")
+                                    {
+                                        <li class="tag ignore">@casedTag</li>
+                                    }
+                                    else if (sanitizedTag == "smoke")
+                                    {
+                                        <li class="tag smoke">@casedTag</li>
+                                    }
+                                    else
+                                    {
+                                        <li class="tag">@casedTag</li>
+                                    }
+                                }
+                            </ul>
+                        }
                         <h3 class="container_scenario_duration"><strong>Scenario duration:</strong> @scenario.TestDuration</h3>
                         @foreach (var step in scenario.Steps)
                         {

--- a/source/VizGurka/Pages/Features/Features.cshtml.cs
+++ b/source/VizGurka/Pages/Features/Features.cshtml.cs
@@ -61,6 +61,7 @@ public class FeaturesModel : PageModel
         {
             Id = f.Id,
             Name = f.Name,
+            Tags = f.Tags,
             Status = f.Status,
             Scenarios = f.Scenarios,
             Rules = f.Rules,

--- a/source/VizGurka/wwwroot/css/feature-content.css
+++ b/source/VizGurka/wwwroot/css/feature-content.css
@@ -31,6 +31,47 @@
   padding-top: 20px;
 }
 
+.tag_list {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 2vw;
+  margin-bottom: 1rem;
+  list-style: none;
+  background-color: whitesmoke;
+  border-radius: 10px;
+  margin: 0;
+  padding: 10px;
+  width: fit-content;
+  gap: 10px;
+  font-size: 1rem;
+  margin-left: 40px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.tag{
+  padding: 5px;
+  margin: 5px;
+  background-color: #f0f0f0;
+  box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.75);
+  border-radius: 5px;
+  font-weight: 700;
+}
+
+.ignore {
+  background-color: rgba(240, 205, 8);
+  color: rgb(255, 255, 0);
+}
+
+.scenario_tags{
+  margin-left: 0;
+}
+
+.smoke {
+  background-color: gray;
+  color: white;
+}
+
 .content_container_duration{
   font-size: 1.5rem;
   font-weight: 700;

--- a/tests/ReqnrollDemo.Spec/Features/Departments/manage-departments.feature
+++ b/tests/ReqnrollDemo.Spec/Features/Departments/manage-departments.feature
@@ -1,3 +1,4 @@
+@feature
 Feature: Manage Departments
 
   As a CEO
@@ -8,12 +9,12 @@ Feature: Manage Departments
   - This is also important
 
   Here is a link for testing: [Reqnroll](https://reqnroll.net)
-
+  @rule @ignore
   Rule: Removing and renaming departments
 
     This rule is **very** important to the CEO.
     Should **only** be *useful* to the CEO.
-
+    @scenario
     Scenario: Remove an existing department
 
       **This** scenario *might* not be used to much.


### PR DESCRIPTION
This pull request introduces changes to enhance the display of tags for features and scenarios in the `Features` page. The changes include adding tag lists in the HTML, updating the model to include tags, and styling the tags in CSS.

### Enhancements to tag display:

* [`source/VizGurka/Pages/Features/Features.cshtml`](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR108-R126): Added logic to display tags for both features and scenarios, including special handling for "ignore" and "smoke" tags. The idea here is that we can continue expanding on this logic if we decide on some certain tags which we now will have special meaning in gurka. But also things like Smoke, Fast, Important we could give special styling because they are tags we can assume will be used often by the users. [[1]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR108-R126) [[2]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR139-R160)
* [`source/VizGurka/Pages/Features/Features.cshtml.cs`](diffhunk://#diff-5fb0f0ebf80cccd901d844464991a219994ac4ca7b0288954acb5bb37769cfd5R64): Updated the `PopulateFeatures` method to include tags in the feature model.

### Styling updates:

* [`source/VizGurka/wwwroot/css/feature-content.css`](diffhunk://#diff-dab53f214ec40a0eca9612c68bf84e716c993fc182fa1aa832d7d26c98260d5cR34-R74): Added CSS styles for the tag list and individual tags, including specific styles for "ignore" and "smoke" tags.

![image](https://github.com/user-attachments/assets/83aa190f-f3f7-4075-9b9c-4e7061924f27)
