### PR TITLE
Create ImageHelper class to find media files in the GurkaFiles directory and copy them into wwwroot on program run.

### DIFF
--- a/source/VizGurka/Helpers/ImageHelper.cs
+++ b/source/VizGurka/Helpers/ImageHelper.cs
@@ -1,0 +1,31 @@
+using System.IO;
+
+namespace VizGurka.Helpers
+{
+    public static class ImageHelper
+    {
+        public static void CopyImageFilesToWwwroot()
+        {
+            string sourceDirectory = Path.Combine(Directory.GetCurrentDirectory(), "bin", "Debug", "net8.0", "GurkaFiles");
+            string destinationDirectory = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "images");
+
+            if (!Directory.Exists(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            string[] extensions = new[] { "*.png", "*.jpeg", "*.jpg", "*.svg", "*.gif" };
+
+            // Copy all files with the specified extensions to the destination directory
+            {
+                string[] files = Directory.GetFiles(sourceDirectory, extension);
+                foreach (string file in files)
+                {
+                    string fileName = Path.GetFileName(file);
+                    string destFile = Path.Combine(destinationDirectory, fileName);
+                    File.Copy(file, destFile, true);
+                }
+            }
+        }
+    }
+}

--- a/source/VizGurka/Program.cs
+++ b/source/VizGurka/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using VizGurka.Helpers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,6 +20,9 @@ var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture(defaultCulture)
     .AddSupportedCultures(supportedCultures)
     .AddSupportedUICultures(supportedCultures);
+
+// Copy media files to wwwroot
+ImageHelper.CopyImageFilesToWwwroot();
 
 var app = builder.Build();
 


### PR DESCRIPTION
This pull request introduces a new helper method to copy image files to the `wwwroot` directory and integrates it into the application startup process.

* **New Helper Method:**
  * [`source/VizGurka/Helpers/ImageHelper.cs`](diffhunk://#diff-e1a697c161f5a28e7846669967a676729f0b3258f29388b6cc5d8e3930b49c07R1-R31): Added a static method `CopyImageFilesToWwwroot` that copies image files from the `GurkaFiles` directory to the `wwwroot/images` directory.

* **Integration into Application Startup:**
  * [`source/VizGurka/Program.cs`](diffhunk://#diff-72bdc78c124e7e388f8593fefd257ed12f3cfdea005bceb5d0b581d4c6f19c3aR4): Imported the `VizGurka.Helpers` namespace to use the new helper method.
  * [`source/VizGurka/Program.cs`](diffhunk://#diff-72bdc78c124e7e388f8593fefd257ed12f3cfdea005bceb5d0b581d4c6f19c3aR24-R26): Called `ImageHelper.CopyImageFilesToWwwroot()` during the application startup to ensure image files are copied to the `wwwroot` directory.

Hopefully we can leverage the gherkin tags(@image/imagename.png for example) to let the user insert images in their tests as long as the media files are in the GurkaFiles dir.