### PR TITLE
Markdown tables now displayed on /features page

### DIFF
--- a/source/VizGurka/Pages/Features/Features.cshtml
+++ b/source/VizGurka/Pages/Features/Features.cshtml
@@ -179,6 +179,10 @@
                                 <img class="container_scenario_status_img"
                                     src="~/icons/@(IconHelper.GetStatusIcon(step.Status)).svg" alt="status icon" />
                                 <strong>@step.Kind</strong> @step.Text
+                                @if (!string.IsNullOrEmpty(step.Table))
+                                {
+                                    <div class="step_table">@Model.MarkdownStringToHtml(step.Table ?? "")</div>
+                                }
                             </div>
                         }
                     }
@@ -256,6 +260,10 @@
                                         <img class="container_scenario_status_img"
                                             src="~/icons/@(IconHelper.GetStatusIcon(step.Status)).svg" alt="status icon" />
                                         <strong>@step.Kind</strong> @step.Text
+                                        @if (!string.IsNullOrEmpty(step.Table))
+                                        {
+                                            <div class="step_table">@Model.MarkdownStringToHtml(step.Table ?? "")</div>
+                                        }
                                     </div>
                                 }
                             }

--- a/source/VizGurka/wwwroot/css/feature-content.css
+++ b/source/VizGurka/wwwroot/css/feature-content.css
@@ -31,7 +31,7 @@
   padding-left: 1.5vw;
 }
 
-.content_container_title{
+.content_container_title {
   font-size: 3rem;
   font-weight: 900;
   margin: 0;
@@ -56,11 +56,11 @@
   margin-bottom: 10px;
 }
 
-.tag{
+.tag {
   padding: 5px;
   margin: 5px;
   background-color: #f0f0f0;
-  box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.75);
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.75);
   border-radius: 5px;
   font-weight: 700;
 }
@@ -70,7 +70,7 @@
   color: rgb(255, 255, 0);
 }
 
-.scenario_tags{
+.scenario_tags {
   margin-left: 0;
 }
 
@@ -79,7 +79,7 @@
   color: white;
 }
 
-.content_container_duration{
+.content_container_duration {
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -88,7 +88,7 @@
   width: 95%;
 }
 
-.container_scenarios_title{
+.container_scenarios_title {
   font-size: 2.5rem;
   font-weight: 700;
   padding-left: 4vw;
@@ -96,60 +96,75 @@
   width: 50%;
 }
 
-.container_scenario_rule{
+.container_scenario_rule {
   font-size: 1.5rem;
   font-weight: 700;
   padding-left: 4vw;
   margin-bottom: 1rem;
 }
 
-.container_scenario_name{
+.container_scenario_name {
   font-size: 1.7rem;
 }
 
-.container_scenario_name h3{
+.container_scenario_name h3 {
   scroll-padding-top: -100px;
 }
 
-[id$="-rule"]{
+[id$="-rule"] {
   scroll-margin-top: 100px;
 }
 
-[id$="-scenario"]{
+[id$="-scenario"] {
   scroll-margin-top: 100px;
 }
 
-[id$="-tag"]{
+[id$="-tag"] {
   scroll-margin-top: 100px;
 }
 
-.scenario_rule_description p{
+.scenario_rule_description p {
   font-size: 1em;
   font-weight: 400;
   margin-bottom: 1rem;
 }
 
-.container_scenario_step{
+.container_scenario_step {
   font-size: 1.3rem;
   font-weight: 400;
   margin-bottom: 1rem;
 }
 
-.container_scenario_duration{
+.step_table {
+  background-color: rgb(167, 165, 165);
+  width: fit-content;
+  margin-top: 10px;
+  border: 1px solid black;
+}
+
+.step_table td {
+  padding: 10px;
+}
+
+.step_table tr {
+  background-color: white;
+}
+
+.container_scenario_duration {
   font-weight: 400;
 }
 
-.scenario_list{
+.scenario_list {
   padding-left: 4vw;
   width: 50%;
 }
 
-.container_scenario_status_img{
+.container_scenario_status_img {
   width: 20px;
   height: 20px;
 }
 
-.container_title_status_img{
+.container_title_status_img {
   width: 40px;
   height: 40px;
 }


### PR DESCRIPTION
* [`source/VizGurka/Pages/Features/Features.cshtml`](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR182-R185): Added conditional rendering to display step tables using the `MarkdownStringToHtml` method if the `step.Table` is not empty. [[1]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR182-R185) [[2]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR263-R266)

Styling for step tables:

* [`source/VizGurka/wwwroot/css/feature-content.css`](diffhunk://#diff-dab53f214ec40a0eca9612c68bf84e716c993fc182fa1aa832d7d26c98260d5cR138-R152): Added CSS styles for the `.step_table` class, including background color, width, margin, border, and padding for table cells and rows.

![image](https://github.com/user-attachments/assets/73154032-df3c-49e7-846d-c5a8b917e684)

![image](https://github.com/user-attachments/assets/9ede2dcb-2f19-408d-bb3e-8d692c3e2ea0)
