### PR TITLE
Parse markdown. Add MarkdownHelper.cs. Remove Markdown logic from feature.cshtml.cs.

### DIFF
--- a/source/VizGurka/Helpers/MarkdownHelper.cs
+++ b/source/VizGurka/Helpers/MarkdownHelper.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Extensions.Tables;
 using Microsoft.AspNetCore.Html;
+using Markdig.Extensions.AutoIdentifiers;
+using Markdig.Extensions.ListExtras;
+
 
 namespace VizGurka.Helpers
 {
@@ -14,10 +17,9 @@ namespace VizGurka.Helpers
                 RequireHeaderSeparator = false,
                 UseHeaderForColumnCount = true
             })
-            .UseAutoIdentifiers()
-            .UseMediaLinks()
+            .DisableHtml()
             .UseListExtras()
-            .UseAdvancedExtensions()
+            .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
             .Build();
 
         public static IHtmlContent ConvertToHtml(string input)
@@ -32,33 +34,38 @@ namespace VizGurka.Helpers
         private static string NormalizeMarkdown(string input)
         {
             var cleaned = input.Replace("~/", "/");
-
-            //lists
+            
+            // Fix list formatting, To comply with CommonMark
             cleaned = Regex.Replace(cleaned,
-                @"^(\s*)([-*+])(\s*)",
-                m => $"{m.Groups[1].Value}{m.Groups[2].Value} ",
+                @"^[ \t]*([*\-+])\s+",
+                m => $"{m.Groups[1].Value} ",
                 RegexOptions.Multiline);
 
-            //links
+            // Ensure blank line before lists
             cleaned = Regex.Replace(cleaned,
-                @"(\S)\s*($$[^$$]+$$$$[^)]+$$)\s*",
-                "$1 $2",
+                @"(\S.*?)(\r?\n)([*\-+])",
+                "$1$2\n$3",
                 RegexOptions.Multiline);
 
-            //tables
+            // Clean up table formatting
             cleaned = Regex.Replace(cleaned,
                 @"^\s*(\|.*\|)\s*$",
                 m => m.Groups[1].Value,
                 RegexOptions.Multiline);
 
-            //Remove ALL leading/trailing whitespace from images
             return string.Join("\n", cleaned.Split('\n')
                 .Select(line =>
                 {
                     var trimmed = line.TrimStart();
-                    return trimmed.StartsWith("![")
-                        ? trimmed
-                        : line;
+                    // Handle images by trimming entire line
+                    if (trimmed.StartsWith("!["))
+                        return trimmed;
+
+                    // Check if current line is part of a list or table without altering its original spacing
+                    bool isList = Regex.IsMatch(line, @"^\s*([*\-+]|\d+\.)\s+");
+                    bool isTableRow = Regex.IsMatch(line, @"^\s*\|");
+
+                    return (isList || isTableRow) ? line : line.TrimStart();
                 }));
         }
 

--- a/source/VizGurka/Helpers/MarkdownHelper.cs
+++ b/source/VizGurka/Helpers/MarkdownHelper.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using Markdig;
+using Markdig.Extensions.Tables;
+using Microsoft.AspNetCore.Html;
+
+namespace VizGurka.Helpers
+{
+    public static class MarkdownHelper
+    {
+        private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+            .UsePipeTables(new PipeTableOptions
+            {
+                RequireHeaderSeparator = false,
+                UseHeaderForColumnCount = true
+            })
+            .UseAutoIdentifiers()
+            .UseMediaLinks()
+            .UseListExtras()
+            .UseAdvancedExtensions()
+            .Build();
+
+        public static IHtmlContent ConvertToHtml(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return HtmlString.Empty;
+
+            var adjusted = NormalizeMarkdown(input);
+            return new HtmlString(Markdig.Markdown.ToHtml(adjusted, Pipeline));
+        }
+
+        private static string NormalizeMarkdown(string input)
+        {
+            var cleaned = input.Replace("~/", "/");
+
+            //lists
+            cleaned = Regex.Replace(cleaned,
+                @"^(\s*)([-*+])(\s*)",
+                m => $"{m.Groups[1].Value}{m.Groups[2].Value} ",
+                RegexOptions.Multiline);
+
+            //links
+            cleaned = Regex.Replace(cleaned,
+                @"(\S)\s*($$[^$$]+$$$$[^)]+$$)\s*",
+                "$1 $2",
+                RegexOptions.Multiline);
+
+            //tables
+            cleaned = Regex.Replace(cleaned,
+                @"^\s*(\|.*\|)\s*$",
+                m => m.Groups[1].Value,
+                RegexOptions.Multiline);
+
+            //Remove ALL leading/trailing whitespace from images
+            return string.Join("\n", cleaned.Split('\n')
+                .Select(line =>
+                {
+                    var trimmed = line.TrimStart();
+                    return trimmed.StartsWith("![")
+                        ? trimmed
+                        : line;
+                }));
+        }
+
+    }
+
+}

--- a/source/VizGurka/Pages/Features/Features.cshtml
+++ b/source/VizGurka/Pages/Features/Features.cshtml
@@ -139,6 +139,7 @@
                         </ul>
                     }
                     <p class="content_container_duration">Test Duration: @Model.SelectedFeature.TestDuration</p>
+                    <div class="content_container_description">@Model.MarkdownStringToHtml(Model.SelectedFeature.Description ?? string.Empty)</div>
                 </div>
                 <h2 class="container_scenarios_title">Scenarios</h2>
                 <ul class="scenario_list">

--- a/source/VizGurka/Pages/Features/Features.cshtml
+++ b/source/VizGurka/Pages/Features/Features.cshtml
@@ -1,6 +1,7 @@
 @page "/features/{productName}/{id:guid}/{featureId:guid?}/{rule?}"
 @model VizGurka.Pages.Features.FeaturesModel
 @using Microsoft.Extensions.Localization
+@using VizGurka.Helpers
 @using System.Globalization
 @inject IStringLocalizer<FeaturesModel> Localizer
 @{
@@ -139,7 +140,7 @@
                         </ul>
                     }
                     <p class="content_container_duration">Test Duration: @Model.SelectedFeature.TestDuration</p>
-                    <div class="content_container_description">@Model.MarkdownStringToHtml(Model.SelectedFeature.Description ?? string.Empty)</div>
+                    <div class="content_container_description">@MarkdownHelper.ConvertToHtml(Model.SelectedFeature.Description ?? string.Empty)</div>
                 </div>
                 <h2 class="container_scenarios_title">Scenarios</h2>
                 <ul class="scenario_list">
@@ -180,6 +181,10 @@
                                 <img class="container_scenario_status_img"
                                     src="~/icons/@(IconHelper.GetStatusIcon(step.Status)).svg" alt="status icon" />
                                 <strong>@step.Kind</strong> @step.Text
+                                @if (!string.IsNullOrEmpty(step.Table))
+                                {
+                                    <div class="step_table">@MarkdownHelper.ConvertToHtml(step.Table ?? "")</div>
+                                }
                             </div>
                         }
                     }
@@ -216,7 +221,7 @@
                             }
                             <div class="scenario_rule_description" id="scenario_rule_description">
 
-                                @Model.MarkdownStringToHtml(rule.Description ?? string.Empty)</div>
+                                @MarkdownHelper.ConvertToHtml(rule.Description ?? string.Empty)</div>
 
                         </div>
                         <ul class="scenario_list">
@@ -257,6 +262,12 @@
                                         <img class="container_scenario_status_img"
                                             src="~/icons/@(IconHelper.GetStatusIcon(step.Status)).svg" alt="status icon" />
                                         <strong>@step.Kind</strong> @step.Text
+                                        @if (!string.IsNullOrEmpty(step.Table))
+                                            {   
+                                                <div class="table-scroll-wrapper">
+                                                    <table class="step_table">@MarkdownHelper.ConvertToHtml(step.Table ?? "")</table>
+                                                </div>
+                                            }
                                     </div>
                                 }
                             }

--- a/source/VizGurka/Pages/Features/Features.cshtml.cs
+++ b/source/VizGurka/Pages/Features/Features.cshtml.cs
@@ -91,8 +91,13 @@ public class FeaturesModel : PageModel
 
     public IHtmlContent MarkdownStringToHtml(string input)
     {
-        var trimmedInput = input.Trim();
-        return new HtmlString(Markdown.ToHtml(trimmedInput, Pipeline));
+        var adjustedMarkdown = input
+            .Replace("\r\n", " ")
+            .Replace("\n", " ")
+            .Replace("\r", " ")
+            .Replace("~/", "/");
+
+        return new HtmlString(Markdig.Markdown.ToHtml(adjustedMarkdown, Pipeline));
     }
 
 }

--- a/source/VizGurka/Pages/Features/Features.cshtml.cs
+++ b/source/VizGurka/Pages/Features/Features.cshtml.cs
@@ -1,10 +1,10 @@
-using Markdig;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SpecGurka.GurkaSpec;
 using VizGurka.Helpers;
 using Microsoft.Extensions.Localization;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace VizGurka.Pages.Features;
 
@@ -20,7 +20,6 @@ public class FeaturesModel : PageModel
     public List<Scenario> Scenarios { get; set; } = new List<Scenario>();
     public List<Guid> FeatureIds { get; set; } = new List<Guid>();
     public Feature? SelectedFeature { get; set; } = null;
-    public MarkdownPipeline Pipeline { get; set; } = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
     public string GithubLink { get; set; } = string.Empty;
     public string CommitId { get; set; } = string.Empty;
     public string ProductName { get; set; } = string.Empty;
@@ -88,16 +87,4 @@ public class FeaturesModel : PageModel
     {
         FeatureIds = Features.Select(f => f.Id).ToList();
     }
-
-    public IHtmlContent MarkdownStringToHtml(string input)
-    {
-        var adjustedMarkdown = input
-            .Replace("\r\n", " ")
-            .Replace("\n", " ")
-            .Replace("\r", " ")
-            .Replace("~/", "/");
-
-        return new HtmlString(Markdig.Markdown.ToHtml(adjustedMarkdown, Pipeline));
-    }
-
 }

--- a/source/VizGurka/Pages/Search/Search.cshtml.cs
+++ b/source/VizGurka/Pages/Search/Search.cshtml.cs
@@ -73,7 +73,7 @@ namespace VizGurka.Pages.Search
 
             if (latestRun != null)
             {
-                LatestRunDate = DateTime.Parse(latestRun.DateAndTime);
+                LatestRunDate = DateTime.Parse(latestRun.RunDate);
             }
 
             if (!string.IsNullOrEmpty(Query) && product != null)

--- a/source/VizGurka/wwwroot/css/feature-content.css
+++ b/source/VizGurka/wwwroot/css/feature-content.css
@@ -38,6 +38,13 @@
   padding-top: 20px;
 }
 
+.content_container_description{
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-left: 2.5vw;
+}
+
 .tag_list {
   display: flex;
   flex-wrap: wrap;

--- a/source/VizGurka/wwwroot/css/feature-content.css
+++ b/source/VizGurka/wwwroot/css/feature-content.css
@@ -31,18 +31,24 @@
   padding-left: 1.5vw;
 }
 
-.content_container_title{
+.content_container_title {
   font-size: 3rem;
   font-weight: 900;
   margin: 0;
   padding-top: 20px;
 }
 
-.content_container_description{
+.content_container_description {
   font-size: 1.5rem;
   font-weight: 600;
   margin-bottom: 1rem;
   padding-left: 2.5vw;
+}
+
+.content_container_description p {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .tag_list {
@@ -63,11 +69,11 @@
   margin-bottom: 10px;
 }
 
-.tag{
+.tag {
   padding: 5px;
   margin: 5px;
   background-color: #f0f0f0;
-  box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.75);
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.75);
   border-radius: 5px;
   font-weight: 700;
 }
@@ -77,7 +83,7 @@
   color: rgb(255, 255, 0);
 }
 
-.scenario_tags{
+.scenario_tags {
   margin-left: 0;
 }
 
@@ -86,7 +92,7 @@
   color: white;
 }
 
-.content_container_duration{
+.content_container_duration {
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -95,7 +101,7 @@
   width: 95%;
 }
 
-.container_scenarios_title{
+.container_scenarios_title {
   font-size: 2.5rem;
   font-weight: 700;
   padding-left: 4vw;
@@ -103,60 +109,75 @@
   width: 50%;
 }
 
-.container_scenario_rule{
+.container_scenario_rule {
   font-size: 1.5rem;
   font-weight: 700;
   padding-left: 4vw;
   margin-bottom: 1rem;
 }
 
-.container_scenario_name{
+.container_scenario_name {
   font-size: 1.7rem;
 }
 
-.container_scenario_name h3{
+.container_scenario_name h3 {
   scroll-padding-top: -100px;
 }
 
-[id$="-rule"]{
+[id$="-rule"] {
   scroll-margin-top: 100px;
 }
 
-[id$="-scenario"]{
+[id$="-scenario"] {
   scroll-margin-top: 100px;
 }
 
-[id$="-tag"]{
+[id$="-tag"] {
   scroll-margin-top: 100px;
 }
 
-.scenario_rule_description p{
+.step_table {
+  background-color: rgb(167, 165, 165);
+  width: fit-content;
+  margin-top: 10px;
+  border: 1px solid black;
+}
+
+.step_table td {
+  padding: 10px;
+}
+
+.step_table tr {
+  background-color: white;
+}
+
+.scenario_rule_description p {
   font-size: 1em;
   font-weight: 400;
   margin-bottom: 1rem;
 }
 
-.container_scenario_step{
+.container_scenario_step {
   font-size: 1.3rem;
   font-weight: 400;
   margin-bottom: 1rem;
 }
 
-.container_scenario_duration{
+.container_scenario_duration {
   font-weight: 400;
 }
 
-.scenario_list{
+.scenario_list {
   padding-left: 4vw;
   width: 50%;
 }
 
-.container_scenario_status_img{
+.container_scenario_status_img {
   width: 20px;
   height: 20px;
 }
 
-.container_title_status_img{
+.container_title_status_img {
   width: 40px;
   height: 40px;
 }


### PR DESCRIPTION
We are facing a big issue here regarding markdown. Apparently when parsing markdown it is very sensitive to \r & \n.
So the obvious solution would be to clean up the strings before sending it through the markdown pipe. But this breaks the structure of the original Gherkin document as removing new lines etc will also remove the new line in the parsed Markdown that is displayed.

To combat this I created the MarkdownHelper which uses Regex to normalize the markdown with element specific rules to make sure the gurka properties are being processed correctly. This will probably become an issue later on with new markdown stuff being introduced and the parser not being able to parse properly because some regex rule might screw with it.

An alternative to this could be to try and do this cleanup in the gurka file generation, although it would mean altering the data which is a bad idea.

Another alternative would be to enforce rules in the gherkin file. Dont use indents etc, but this is unrealistic.

I'm pleased to have gotten it working, But I see the potential issues with this implementation.



* [`source/VizGurka/Helpers/MarkdownHelper.cs`](diffhunk://#diff-c0682bbc6f3557d221aa611a2bf1374d33067a96275e1393b0044b3ac146ece1R1-R67): Introduced a new `MarkdownHelper` class that provides methods to convert markdown text to HTML using the Markdig library and normalizes markdown input.

Updates to the `Features` page:

* [`source/VizGurka/Pages/Features/Features.cshtml`](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR4): Updated the `Features` page to use the new `MarkdownHelper.ConvertToHtml` method for rendering markdown content. This includes descriptions, tables, and scenario rules. [[1]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR4) [[2]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR143) [[3]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR184-R187) [[4]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dL218-R224) [[5]](diffhunk://#diff-3baaf38704ff75d0d02d736c9c67f3dc168009148a4331ec987e81f3f5fefb2dR265-R270)
* [`source/VizGurka/Pages/Features/Features.cshtml.cs`](diffhunk://#diff-5fb0f0ebf80cccd901d844464991a219994ac4ca7b0288954acb5bb37769cfd5L1-R7): Removed the old markdown processing method `MarkdownStringToHtml` and the `MarkdownPipeline` property, as they are now handled by the `MarkdownHelper` class. [[1]](diffhunk://#diff-5fb0f0ebf80cccd901d844464991a219994ac4ca7b0288954acb5bb37769cfd5L1-R7) [[2]](diffhunk://#diff-5fb0f0ebf80cccd901d844464991a219994ac4ca7b0288954acb5bb37769cfd5L23) [[3]](diffhunk://#diff-5fb0f0ebf80cccd901d844464991a219994ac4ca7b0288954acb5bb37769cfd5L91-L97)

![image](https://github.com/user-attachments/assets/06f04e86-eb4a-4464-a705-62f6f7e59161)

![image](https://github.com/user-attachments/assets/1b99eaed-8b73-43ce-ac68-92cdbbb7a722)

![image](https://github.com/user-attachments/assets/83797dc6-2f0d-4c01-b381-20bfd1e66edf)

