### PR TITLE
Scenario outline support for Gengurka. Status Propagation refactorisation.

### DIFF
--- a/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
+++ b/source/GenGurka/Extensions/GherkinDocumentExtensions.cs
@@ -124,8 +124,8 @@ internal static class GherkinDocumentExtensions
             {
                 Name = scenario.Name,
                 Description = scenario.Description?.TrimStart() ?? string.Empty,
-                Examples = scenario.Examples?.FirstOrDefault()?.ToMarkDownString() ?? string.Empty
-
+                Examples = scenario.Examples?.FirstOrDefault()?.ToMarkDownString() ?? string.Empty,
+                IsOutline = true
             };
 
             foreach (var step in scenario.Steps)
@@ -147,12 +147,17 @@ internal static class GherkinDocumentExtensions
         }
         else
         {
-            // Regular scenario handling (unchanged)
+            // Regular scenario handling
             var gurkaScenario = new GurkaSpec.Scenario
             {
                 Name = scenario.Name,
                 Description = scenario.Description?.TrimStart() ?? string.Empty,
             };
+
+            if (gurkaScenario.IsOutline && scenario.Examples?.FirstOrDefault() != null)
+            {
+                gurkaScenario.Examples = scenario.Examples.FirstOrDefault().ToMarkDownString();
+            }
 
             foreach (var step in scenario.Steps)
             {
@@ -196,7 +201,8 @@ internal static class GherkinDocumentExtensions
                 {
                     Name = ReplaceParameters(scenarioOutline.Name, headers, row),
                     Description = templateScenario.Description,
-                    Tags = new List<string>(templateScenario.Tags)
+                    Tags = new List<string>(templateScenario.Tags),
+                    IsOutlineChild = true
                 };
 
                 // Process each step, replacing parameters

--- a/source/GenGurka/Extensions/ScenarioOutlineExtensions.cs
+++ b/source/GenGurka/Extensions/ScenarioOutlineExtensions.cs
@@ -1,0 +1,155 @@
+using SpecGurka.GurkaSpec;
+using TrxFileParser.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using SpecGurka.GenGurka.Helpers;
+using SpecGurka.GenGurka.Extensions;
+namespace SpecGurka.GenGurka.Extensions;
+
+internal static class ScenarioOutlineExtensions
+{
+
+    public static void ProcessScenarios(List<Scenario> scenarios, Dictionary<string, List<UnitTestResult>> testResults)
+    {
+        var processedTestIds = new HashSet<string>();
+
+        // Separate scenarios by type
+        var regularScenarios = scenarios.Where(s => !s.IsOutline && !s.IsOutlineChild).ToList();
+        var outlineTemplates = scenarios.Where(s => s.IsOutline).ToList();
+        var outlineInstances = scenarios.Where(s => s.IsOutlineChild).ToList();
+
+        //regular scenario
+        foreach (var scenario in regularScenarios)
+        {
+            ProcessScenario(scenario, testResults, processedTestIds);
+        }
+
+        //outline children
+        foreach (var scenario in outlineInstances)
+        {
+            ProcessScenario(scenario, testResults, processedTestIds);
+        }
+
+        //outline templates based on their children
+        foreach (var template in outlineTemplates)
+        {
+            var children = outlineInstances.Where(s => s.Name.StartsWith(template.Name)).ToList();
+
+            if (children.Any())
+            {
+                if (children.Any(c => c.Status == Status.Failed))
+                {
+                    //any child failed, template is failed
+                    template.Status = Status.Failed;
+                }
+                else if (children.All(c => c.Status == Status.NotImplemented))
+                {
+                    template.Status = Status.NotImplemented;
+                }
+                else if (children.Any(c => c.Status == Status.Passed))
+                {
+                    template.Status = Status.Passed;
+                }
+
+                // Calculate aggregate duration for template
+                TimeSpan totalDuration = TimeSpan.Zero;
+                foreach (var child in children)
+                {
+                    if (TimeSpan.TryParse(child.TestDuration, out var duration))
+                    {
+                        totalDuration = totalDuration.Add(duration);
+                    }
+                }
+                template.TestDuration = totalDuration.ToString(@"hh\:mm\:ss\.fffffff");
+            }
+            else
+            {
+                ProcessScenario(template, testResults, processedTestIds);
+            }
+        }
+    }
+
+    public static void ProcessScenario(Scenario scenario, Dictionary<string, List<UnitTestResult>> testResults, HashSet<string> processedTestIds)
+    {
+        // Skip if scenario already has a non-zero duration
+        if (!IsZeroDuration(scenario.TestDuration))
+        {
+            return;
+        }
+
+        var matchedResult = TestRunExtensions.FindMatchingTestResult(scenario, testResults);
+
+        if (matchedResult != null)
+        {
+            if (processedTestIds.Contains(matchedResult.TestId))
+            {
+                return;
+            }
+
+            StatusApplicationHelper.ApplyTestStatusToScenario(scenario, matchedResult);
+
+            if (TimeSpan.TryParse(matchedResult.Duration, out TimeSpan duration))
+            {
+                string formattedDuration = duration.ToString(@"hh\:mm\:ss\.fffffff");
+                scenario.TestDuration = formattedDuration;
+
+                processedTestIds.Add(matchedResult.TestId);
+            }
+        }
+
+        else
+        {
+            if (scenario.Status == Status.Passed)
+            {
+                scenario.TestDuration = TimeSpan.Zero.ToString(@"hh\:mm\:ss\.fffffff");
+            }
+        }
+    }
+    public static string ExtractScenarioNameFromTestName(string testName)
+    {
+        string name = testName;
+
+        if (name.Contains("."))
+        {
+            name = name.Split('.').Last();
+        }
+
+        name = Regex.Replace(name, "([a-z])([A-Z])", "$1 $2");
+
+        return name.ToLowerInvariant();
+    }
+
+    private static bool IsZeroDuration(string duration)
+    {
+        if (string.IsNullOrEmpty(duration))
+        {
+            return true;
+        }
+
+        if (duration == "00:00:00" ||
+            duration == "00:00:00.0000000" ||
+            duration == "00:00:00.000000" ||
+            duration == "00:00:00.00000" ||
+            duration == "00:00:00.0000" ||
+            duration == "00:00:00.000" ||
+            duration == "00:00:00.00" ||
+            duration == "00:00:00.0" ||
+            duration == "0" ||
+            duration == "0.0")
+        {
+            return true;
+        }
+
+        // Try parsing as TimeSpan
+        if (TimeSpan.TryParse(duration, out TimeSpan ts))
+        {
+            return ts.TotalMilliseconds == 0;
+        }
+
+        // If we can't parse it, assume it's not zero
+        return false;
+    }
+
+}

--- a/source/GenGurka/Extensions/TestRunExtensions.cs
+++ b/source/GenGurka/Extensions/TestRunExtensions.cs
@@ -1,4 +1,5 @@
 using SpecGurka.GurkaSpec;
+using SpecGurka.GenGurka.Helpers;
 using TrxFileParser.Models;
 using System;
 using System.Collections.Generic;
@@ -18,7 +19,7 @@ internal static class TestRunExtensions
         {
             if (utr.Outcome != "NotExecuted" && !string.IsNullOrEmpty(utr.Duration))
             {
-                string cleanKey = ExtractScenarioNameFromTestName(utr.TestName);
+                string cleanKey = ScenarioOutlineExtensions.ExtractScenarioNameFromTestName(utr.TestName);
 
                 if (!testResults.ContainsKey(cleanKey))
                 {
@@ -37,14 +38,20 @@ internal static class TestRunExtensions
 
         foreach (var feature in gurkaProject.Features)
         {
-            ProcessScenarios(feature.Scenarios, testResults);
+            ScenarioOutlineExtensions.ProcessScenarios(feature.Scenarios, testResults);
 
             foreach (var rule in feature.Rules)
             {
-                ProcessScenarios(rule.Scenarios, testResults);
+                ScenarioOutlineExtensions.ProcessScenarios(rule.Scenarios, testResults);
             }
+        }
 
-            // Force recalculations
+        // This needs to be outside the feature loop!
+        StatusPropagationHelper.PropagateStatusesToParents(gurkaProject);
+
+        // Force recalculations
+        foreach (var feature in gurkaProject.Features)
+        {
             foreach (var rule in feature.Rules)
             {
                 string ruleDuration = rule.TestDuration;
@@ -56,84 +63,21 @@ internal static class TestRunExtensions
         string productDuration = gurkaProject.TestDuration;
     }
 
-    private static void ProcessScenarios(List<Scenario> scenarios, Dictionary<string, List<UnitTestResult>> testResults)
-    {
-        var processedTestIds = new HashSet<string>();
-
-        //regular scenarios first, then outlines
-        var regularScenarios = scenarios.Where(s => !s.IsOutline && !s.IsOutlineChild).ToList();
-        var outlineTemplates = scenarios.Where(s => s.IsOutline).ToList();
-        var outlineInstances = scenarios.Where(s => s.IsOutlineChild).ToList();
-
-        foreach (var scenario in regularScenarios)
-        {
-            ProcessScenario(scenario, testResults, processedTestIds);
-        }
-
-        foreach (var scenario in outlineTemplates)
-        {
-            ProcessScenario(scenario, testResults, processedTestIds);
-        }
-
-        foreach (var scenario in outlineInstances)
-        {
-            ProcessScenario(scenario, testResults, processedTestIds);
-        }
-    }
-
-    private static void ProcessScenario(Scenario scenario, Dictionary<string, List<UnitTestResult>> testResults, HashSet<string> processedTestIds)
-    {
-        // Skip if scenario already has a non-zero duration
-        if (!IsZeroDuration(scenario.TestDuration))
-        {
-            return;
-        }
-
-        var matchedResult = FindMatchingTestResult(scenario, testResults);
-
-        if (matchedResult != null)
-        {
-            if (processedTestIds.Contains(matchedResult.TestId))
-            {
-                return;
-            }
-
-            ApplyTestStatusToScenario(scenario, matchedResult);
-
-            if (TimeSpan.TryParse(matchedResult.Duration, out TimeSpan duration))
-            {
-                string formattedDuration = duration.ToString(@"hh\:mm\:ss\.fffffff");
-                scenario.TestDuration = formattedDuration;
-
-                processedTestIds.Add(matchedResult.TestId);
-            }
-        }
-
-        else
-        {
-            if (scenario.Status == Status.Passed)
-            {
-                scenario.TestDuration = TimeSpan.Zero.ToString(@"hh\:mm\:ss\.fffffff");
-            }
-        }
-    }
-
-    private static UnitTestResult? FindMatchingTestResult(Scenario scenario, Dictionary<string, List<UnitTestResult>> testResults)
+    public static UnitTestResult? FindMatchingTestResult(Scenario scenario, Dictionary<string, List<UnitTestResult>> testResults)
     {
         string scenarioName = scenario.Name;
+        var exampleParams = new Dictionary<string, string>();
 
-        // First, try exact match by normalized name
+        //try exact match by normalized name
         string cleanName = NormalizeText(scenarioName);
         if (testResults.TryGetValue(cleanName, out var directMatches) && directMatches.Count > 0)
         {
-            Console.WriteLine($"DEBUG: Found direct match for '{scenarioName}' by normalized name");
             return directMatches[0];
         }
 
         // For scenario outline, try to match by example parameters
         if (!string.IsNullOrEmpty(scenario.Examples) && scenario.Examples.StartsWith("Example:"))
         {
-            var exampleParams = new Dictionary<string, string>();
             string exampleContent = scenario.Examples.Substring("Example: ".Length);
 
             var pairs = exampleContent.Split(',');
@@ -151,71 +95,68 @@ internal static class TestRunExtensions
                     exampleParams[key] = value;
                 }
             }
+        }
 
-            //try to match by scenario name + parameters
-            foreach (var entry in testResults)
+        foreach (var entry in testResults)
+        {
+            // scenario name AND parameter values?
+            bool containsScenarioName = entry.Key.Contains(scenarioName, StringComparison.OrdinalIgnoreCase) ||
+                    NormalizeText(entry.Key).Contains(cleanName, StringComparison.OrdinalIgnoreCase);
+
+            if (containsScenarioName)
             {
-                // Check if contains both the scenario name AND parameter values
-                bool containsScenarioName = entry.Key.Contains(scenarioName, StringComparison.OrdinalIgnoreCase) ||
-                                           NormalizeText(entry.Key).Contains(cleanName, StringComparison.OrdinalIgnoreCase);
-
-                if (containsScenarioName)
+                bool allParamsInName = true;
+                foreach (var param in exampleParams)
                 {
-                    bool allParamsInName = true;
-                    foreach (var param in exampleParams)
+                    if (!entry.Key.Contains(param.Value, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (!entry.Key.Contains(param.Value, StringComparison.OrdinalIgnoreCase))
-                        {
-                            allParamsInName = false;
-                            break;
-                        }
-                    }
-
-                    if (allParamsInName && exampleParams.Count > 0)
-                    {
-                        Console.WriteLine($"DEBUG: Found match for outline example with parameters in test name: {entry.Key}");
-                        return entry.Value[0];
+                        allParamsInName = false;
+                        break;
                     }
                 }
-            }
 
-            // Then, try to match by output content containing parameter values
-            foreach (var entry in testResults)
-            {
-                foreach (var result in entry.Value)
+                if (allParamsInName && exampleParams.Count > 0)
                 {
-                    if (result.Output?.StdOut == null) continue;
-
-                    bool allParamsFound = true;
-                    foreach (var param in exampleParams)
-                    {
-                        // Check if the parameter value is in the test output
-                        if (!result.Output.StdOut.Contains(param.Value))
-                        {
-                            allParamsFound = false;
-                            break;
-                        }
-                    }
-
-                    if (allParamsFound && exampleParams.Count > 0)
-                    {
-                        return result;
-                    }
+                    return entry.Value[0];
                 }
             }
         }
 
-        // Match by scenario name embedded in test name
+        // output containing parameter values?
         foreach (var entry in testResults)
         {
-            if (entry.Key.Contains(scenarioName, StringComparison.OrdinalIgnoreCase) ||
-                NormalizeText(entry.Key).Contains(cleanName, StringComparison.OrdinalIgnoreCase))
+            foreach (var result in entry.Value)
+            {
+                if (result.Output?.StdOut == null) continue;
+
+                bool allParamsFound = true;
+                foreach (var param in exampleParams)
+                {
+                    if (!result.Output.StdOut.Contains(param.Value))
+                    {
+                        allParamsFound = false;
+                        break;
+                    }
+                }
+
+                if (allParamsFound && exampleParams.Count > 0)
+                {
+                    return result;
+                }
+            }
+        }
+
+        // scenario name embedded in test name?
+        foreach (var entry in testResults)
+        {
+            if ((entry.Key.Contains(scenarioName, StringComparison.OrdinalIgnoreCase) ||
+                NormalizeText(entry.Key).Contains(cleanName, StringComparison.OrdinalIgnoreCase)))
             {
                 return entry.Value[0];
             }
         }
 
-        // Match by exact step text in output
+        // exact step text in output?
         foreach (var entry in testResults)
         {
             foreach (var result in entry.Value)
@@ -247,7 +188,7 @@ internal static class TestRunExtensions
         string[] scenarioWords = scenarioName.Split(new[] { ' ', '_', '-' }, StringSplitOptions.RemoveEmptyEntries);
         if (scenarioWords.Length > 0)
         {
-            // Try multi-word match first
+            // multi-word match?
             foreach (var entry in testResults)
             {
                 bool allWordsFound = true;
@@ -264,14 +205,14 @@ internal static class TestRunExtensions
                     matchedWords++;
                 }
 
-                if (allWordsFound && matchedWords > 1) // Require at least 2 words to match
+                if (allWordsFound && matchedWords > 1)
                 {
                     return entry.Value[0];
                 }
             }
 
-            // Finally, try individual significant word match
-            var significantWords = scenarioWords.Where(w => w.Length > 4).ToArray(); // Use only longer words
+            // individual significant word match?
+            var significantWords = scenarioWords.Where(w => w.Length > 4).ToArray();
             if (significantWords.Length > 0)
             {
                 foreach (var entry in testResults)
@@ -286,122 +227,8 @@ internal static class TestRunExtensions
                 }
             }
         }
-        
+
         return null;
-    }
-    private static void ApplyTestStatusToScenario(Scenario scenario, UnitTestResult result)
-    {
-        // Set the scenario status based on the <outcome> property
-        switch (result.Outcome)
-        {
-            case "Passed":
-                scenario.Status = Status.Passed;
-                foreach (var step in scenario.Steps)
-                {
-                    step.Status = Status.Passed;
-                }
-                break;
-            case "Failed":
-                scenario.Status = Status.Failed;
-
-                if (result.Output?.StdOut != null)
-                {
-                    ApplyStepStatuses(scenario, result.Output.StdOut);
-                }
-                else
-                {
-                    // If we can't identify specific failed steps, mark all as failed
-                    // Because if that data is missing something is wrong anyway...
-                    foreach (var step in scenario.Steps)
-                    {
-                        step.Status = Status.Failed;
-                    }
-                }
-                break;
-            case "NotExecuted":
-                scenario.Status = Status.NotImplemented;
-                foreach (var step in scenario.Steps)
-                {
-                    step.Status = Status.NotImplemented;
-                }
-                break;
-            default:
-
-                break;
-        }
-    }
-
-
-    //This should kind of simulate the behaviour of how Reqnroll handles step statuses
-    //If a step fails, all subsequent steps are marked as skipped. In our case we mark them as not implemented
-    private static void ApplyStepStatuses(Scenario scenario, string output)
-    {
-        // Parse the test output to identify step results
-        var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-        int currentStepIndex = -1;
-
-        for (int i = 0; i < lines.Length; i++)
-        {
-            string line = lines[i];
-
-            // Look for step text in the output
-            for (int stepIdx = 0; stepIdx < scenario.Steps.Count; stepIdx++)
-            {
-                var step = scenario.Steps[stepIdx];
-                if (line.Contains(step.Text))
-                {
-                    currentStepIndex = stepIdx;
-                    break;
-                }
-            }
-
-            // Look for step result indicators
-            if (currentStepIndex >= 0 && currentStepIndex < scenario.Steps.Count)
-            {
-                var currentStep = scenario.Steps[currentStepIndex];
-
-                // Check next line for step status
-                if (i + 1 < lines.Length)
-                {
-                    string nextLine = lines[i + 1];
-                    if (nextLine.Contains("-> done:"))
-                    {
-                        currentStep.Status = Status.Passed;
-                    }
-                    else if (nextLine.Contains("-> error:"))
-                    {
-                        currentStep.Status = Status.Failed;
-
-                        // Mark all subsequent steps as skipped
-                        for (int j = currentStepIndex + 1; j < scenario.Steps.Count; j++)
-                        {
-                            scenario.Steps[j].Status = Status.NotImplemented;
-                        }
-
-                        break;
-                    }
-                    else if (nextLine.Contains("-> skipped"))
-                    {
-                        currentStep.Status = Status.NotImplemented;
-                    }
-                }
-            }
-        }
-    }
-
-
-    private static string ExtractScenarioNameFromTestName(string testName)
-    {
-        string name = testName;
-
-        if (name.Contains("."))
-        {
-            name = name.Split('.').Last();
-        }
-
-        name = Regex.Replace(name, "([a-z])([A-Z])", "$1 $2");
-
-        return name.ToLowerInvariant();
     }
 
     private static string NormalizeText(string text)
@@ -421,37 +248,5 @@ internal static class TestRunExtensions
         .Replace("Ä", "A")
         .Replace("Ö", "O")
         .ToLowerInvariant();
-    }
-
-    private static bool IsZeroDuration(string duration)
-    {
-        if (string.IsNullOrEmpty(duration))
-        {
-            return true;
-        }
-
-        // Check common zero duration string formats
-        if (duration == "00:00:00" ||
-            duration == "00:00:00.0000000" ||
-            duration == "00:00:00.000000" ||
-            duration == "00:00:00.00000" ||
-            duration == "00:00:00.0000" ||
-            duration == "00:00:00.000" ||
-            duration == "00:00:00.00" ||
-            duration == "00:00:00.0" ||
-            duration == "0" ||
-            duration == "0.0")
-        {
-            return true;
-        }
-
-        // Try parsing as TimeSpan
-        if (TimeSpan.TryParse(duration, out TimeSpan ts))
-        {
-            return ts.TotalMilliseconds == 0;
-        }
-
-        // If we can't parse it, assume it's not zero
-        return false;
     }
 }

--- a/source/GenGurka/Helpers/ScenarioOutlineDataTableHelper.cs
+++ b/source/GenGurka/Helpers/ScenarioOutlineDataTableHelper.cs
@@ -1,0 +1,75 @@
+using SpecGurka.GurkaSpec;
+using Background = Gherkin.Ast.Background;
+using Feature = Gherkin.Ast.Feature;
+using Rule = Gherkin.Ast.Rule;
+using Scenario = Gherkin.Ast.Scenario;
+using DataTable = Gherkin.Ast.DataTable;
+using TableRow = Gherkin.Ast.TableRow;
+using System.Text;
+
+namespace SpecGurka.GenGurka.Extensions;
+
+public static class ScenarioOutlineDataTableHelper
+{
+
+    public static string ProcessDataTable(DataTable dataTable, List<string> headers, TableRow exampleRow)
+    {
+        var sb = new StringBuilder();
+        var rows = dataTable.Rows.ToList();
+
+        if (rows.Count == 0)
+            return string.Empty;
+
+        // Process header row
+        var headerRow = rows[0];
+        var headerCells = headerRow.Cells.ToList();
+
+        sb.Append("|");
+        foreach (var cell in headerCells)
+        {
+            var processedCell = ReplaceParameters(cell.Value, headers, exampleRow);
+            sb.Append($" {processedCell} |");
+        }
+        sb.AppendLine();
+
+        // Add separator row
+        sb.Append("|");
+        for (int i = 0; i < headerCells.Count; i++)
+        {
+            sb.Append(" --- |");
+        }
+        sb.AppendLine();
+
+        // Process data rows
+        for (int i = 1; i < rows.Count; i++)
+        {
+            var rowCells = rows[i].Cells.ToList();
+            sb.Append("|");
+            foreach (var cell in rowCells)
+            {
+                var processedCell = ReplaceParameters(cell.Value, headers, exampleRow);
+                sb.Append($" {processedCell} |");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    public static string ReplaceParameters(string text, List<string> headers, TableRow row)
+    {
+        if (text == null) return string.Empty;
+
+        string result = text;
+        var cells = row.Cells.ToList();
+
+        for (int i = 0; i < headers.Count && i < cells.Count; i++)
+        {
+            var paramName = headers[i];
+            var paramValue = cells[i].Value;
+            result = result.Replace($"<{paramName}>", paramValue);
+        }
+
+        return result;
+    }
+}

--- a/source/GenGurka/Helpers/ScenarioOutlineDataTableHelper.cs
+++ b/source/GenGurka/Helpers/ScenarioOutlineDataTableHelper.cs
@@ -1,8 +1,4 @@
 using SpecGurka.GurkaSpec;
-using Background = Gherkin.Ast.Background;
-using Feature = Gherkin.Ast.Feature;
-using Rule = Gherkin.Ast.Rule;
-using Scenario = Gherkin.Ast.Scenario;
 using DataTable = Gherkin.Ast.DataTable;
 using TableRow = Gherkin.Ast.TableRow;
 using System.Text;

--- a/source/GenGurka/Helpers/StatusApplicationHelper.cs
+++ b/source/GenGurka/Helpers/StatusApplicationHelper.cs
@@ -1,0 +1,50 @@
+using SpecGurka.GurkaSpec;
+using TrxFileParser.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SpecGurka.GenGurka.Helpers;
+
+public static class StatusApplicationHelper
+{
+    // This method applied the initial status to a scenario based on ACTUAL .trx file result
+    // The statuses being applied here are the truth
+    public static void ApplyTestStatusToScenario(Scenario scenario, UnitTestResult result)
+    {
+        if (scenario.Tags.Contains("@ignore"))
+        {
+            return;
+        }
+
+        // Direct 1:1 mapping from TRX <outcome>
+        switch (result.Outcome?.ToLowerInvariant())
+        {
+            case "passed":
+                scenario.Status = Status.Passed;
+                foreach (var step in scenario.Steps)
+                {
+                    step.Status = Status.Passed;
+                }
+                break;
+
+            case "failed":
+                scenario.Status = Status.Failed;
+                foreach (var step in scenario.Steps)
+                {
+                    step.Status = Status.Failed;
+                }
+                break;
+
+            case "notexecuted":
+            default:
+                scenario.Status = Status.NotImplemented;
+                foreach (var step in scenario.Steps)
+                {
+                    step.Status = Status.NotImplemented;
+                }
+                break;
+        }
+    }
+}

--- a/source/GenGurka/Helpers/StatusPropagationHelper.cs
+++ b/source/GenGurka/Helpers/StatusPropagationHelper.cs
@@ -1,0 +1,259 @@
+
+using SpecGurka.GurkaSpec;
+using TrxFileParser.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SpecGurka.GenGurka.Helpers;
+
+public static class StatusPropagationHelper
+{
+    // This method handles the propagation of statuses. This modifies the truth state of the statuses
+    // But propagation happens no where else in the codebase (I hope)
+    public static void PropagateStatusesToParents(Product gurkaProject)
+    {
+        foreach (var feature in gurkaProject.Features)
+        {
+            foreach (var rule in feature.Rules)
+            {
+                if (rule.Tags.Contains("@ignore"))
+                {
+                    rule.Status = Status.NotImplemented;
+
+                    foreach (var scenario in rule.Scenarios)
+                    {
+                        if (!scenario.Tags.Contains("@ignore"))
+                        {
+                            scenario.Tags.Add("@ignore");
+                        }
+
+                        scenario.Status = Status.NotImplemented;
+
+                        foreach (var step in scenario.Steps)
+                        {
+                            step.Status = Status.NotImplemented;
+                        }
+                    }
+                }
+            }
+
+            if (feature.Tags.Contains("@ignore"))
+            {
+                feature.Status = Status.NotImplemented;
+
+                foreach (var rule in feature.Rules)
+                {
+                    if (!rule.Tags.Contains("@ignore"))
+                    {
+                        rule.Tags.Add("@ignore");
+                    }
+
+                    rule.Status = Status.NotImplemented;
+
+                    foreach (var scenario in rule.Scenarios)
+                    {
+                        if (!scenario.Tags.Contains("@ignore"))
+                        {
+                            scenario.Tags.Add("@ignore");
+                        }
+
+                        scenario.Status = Status.NotImplemented;
+
+                        foreach (var step in scenario.Steps)
+                        {
+                            step.Status = Status.NotImplemented;
+                        }
+                    }
+                }
+
+                foreach (var scenario in feature.Scenarios)
+                {
+                    if (!scenario.Tags.Contains("@ignore"))
+                    {
+                        scenario.Tags.Add("@ignore");
+                    }
+
+                    scenario.Status = Status.NotImplemented;
+
+                    foreach (var step in scenario.Steps)
+                    {
+                        step.Status = Status.NotImplemented;
+                    }
+                }
+
+                return;
+            }
+
+            foreach (var rule in feature.Rules)
+            {
+                UpdateRuleStatus(rule);
+            }
+
+            UpdateFeatureStatus(feature);
+        }
+    }
+
+    public static void UpdateRuleStatus(Rule rule)
+    {
+        if (rule.Tags.Contains("@ignore"))
+        {
+            foreach (var scenario in rule.Scenarios)
+            {
+                if (!scenario.Tags.Contains("@ignore"))
+                {
+                    scenario.Tags.Add("@ignore");
+                }
+
+                scenario.Status = Status.NotImplemented;
+
+                foreach (var step in scenario.Steps)
+                {
+                    step.Status = Status.NotImplemented;
+                }
+            }
+
+            rule.Status = Status.NotImplemented;
+            return;
+        }
+
+        if (rule.Scenarios.Any(s => !s.Tags.Contains("@ignore") && s.Status == Status.Failed) ||
+            (rule.Background != null && rule.Background.Status == Status.Failed))
+        {
+            rule.Status = Status.Failed;
+            return;
+        }
+
+        var nonIgnoredScenarios = rule.Scenarios.Where(s => !s.Tags.Contains("@ignore")).ToList();
+        if (nonIgnoredScenarios.Any() && nonIgnoredScenarios.All(s => s.Status == Status.Passed))
+        {
+            rule.Status = Status.Passed;
+            return;
+        }
+
+        rule.Status = Status.NotImplemented;
+    }
+
+    public static void UpdateFeatureStatus(Feature feature)
+    {
+        if (feature.Tags.Contains("@ignore"))
+        {
+            return;
+        }
+
+        if ((feature.Scenarios.Count == 0 || feature.Scenarios.All(s => s.Tags.Contains("@ignore"))) &&
+            (feature.Rules.Count == 0 || feature.Rules.All(r => r.Tags.Contains("@ignore"))))
+        {
+            feature.Status = Status.NotImplemented;
+            return;
+        }
+
+        if (feature.Scenarios.Any(s => !s.Tags.Contains("@ignore") && s.Status == Status.Failed) ||
+            feature.Rules.Any(r => !r.Tags.Contains("@ignore") && r.Status == Status.Failed) ||
+            (feature.Background != null && feature.Background.Status == Status.Failed))
+        {
+            feature.Status = Status.Failed;
+            return;
+        }
+
+        bool hasNonIgnoredItems =
+            feature.Scenarios.Any(s => !s.Tags.Contains("@ignore")) ||
+            feature.Rules.Any(r => !r.Tags.Contains("@ignore"));
+
+        bool allNonIgnoredPassed =
+            feature.Scenarios.Where(s => !s.Tags.Contains("@ignore")).All(s => s.Status == Status.Passed) &&
+            feature.Rules.Where(r => !r.Tags.Contains("@ignore")).All(r => r.Status == Status.Passed);
+
+        if (hasNonIgnoredItems && allNonIgnoredPassed)
+        {
+            feature.Status = Status.Passed;
+            return;
+        }
+
+        feature.Status = Status.NotImplemented;
+    }
+
+    public static void ApplyStepStatuses(Scenario scenario, string output)
+    {
+        var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        int currentStepIndex = -1;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i];
+
+            // Look for step text in the output
+            for (int stepIdx = 0; stepIdx < scenario.Steps.Count; stepIdx++)
+            {
+                var step = scenario.Steps[stepIdx];
+                if (line.Contains(step.Text))
+                {
+                    currentStepIndex = stepIdx;
+                    break;
+                }
+            }
+
+            if (currentStepIndex >= 0 && currentStepIndex < scenario.Steps.Count)
+            {
+                var currentStep = scenario.Steps[currentStepIndex];
+
+                if (i + 1 < lines.Length)
+                {
+                    string nextLine = lines[i + 1];
+                    if (nextLine.Contains("-> done:"))
+                    {
+                        currentStep.Status = Status.Passed;
+                    }
+                    else if (nextLine.Contains("-> error:"))
+                    {
+                        currentStep.Status = Status.Failed;
+
+                        // Mark all subsequent steps as skipped
+                        for (int j = currentStepIndex + 1; j < scenario.Steps.Count; j++)
+                        {
+                            scenario.Steps[j].Status = Status.NotImplemented;
+                        }
+
+                        break;
+                    }
+                    else if (nextLine.Contains("-> skipped"))
+                    {
+                        currentStep.Status = Status.NotImplemented;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void MarkIgnoredItemsStatus(GurkaSpec.Feature gurkaFeature)
+    {
+        // Set initial status for ignored items, but don't cascade
+
+        if (gurkaFeature.Tags.Contains("@ignore"))
+        {
+            gurkaFeature.Status = Status.NotImplemented;
+        }
+
+        if (gurkaFeature.Background != null && gurkaFeature.Tags.Contains("@ignore"))
+        {
+            gurkaFeature.Background.Status = Status.NotImplemented;
+        }
+
+        foreach (var scenario in gurkaFeature.Scenarios)
+        {
+            if (scenario.Tags.Contains("@ignore"))
+            {
+                scenario.Status = Status.NotImplemented;
+            }
+        }
+
+        foreach (var rule in gurkaFeature.Rules)
+        {
+            if (rule.Tags.Contains("@ignore"))
+            {
+                rule.Status = Status.NotImplemented;
+            }
+        }
+    }
+}

--- a/source/GurkaSpec/Feature.cs
+++ b/source/GurkaSpec/Feature.cs
@@ -18,18 +18,22 @@ public class Feature
     {
         get
         {
-            if (Scenarios.All(scenario => scenario.Status == Status.Passed) &&
-                (Background == null || Background.Status == Status.Passed) &&
-                (Rules.Count == 0 || Rules.All(rule => rule.Status == Status.Passed)))
+            if (Tags.Contains("@ignore"))
             {
-                return Status.Passed;
+                return Status.NotImplemented;
             }
 
             if (Scenarios.Any(scenario => scenario.Status == Status.Failed) ||
                 (Background != null && Background.Status == Status.Failed) ||
-                (Rules.Count > 0 && Rules.Any(rule => rule.Status == Status.Failed)))
+                Rules.Any(rule => rule.Status == Status.Failed))
             {
                 return Status.Failed;
+            }
+
+            if (Scenarios.Any(scenario => scenario.Status == Status.Passed) ||
+                Rules.Any(rule => rule.Status == Status.Passed))
+            {
+                return Status.Passed;
             }
 
             return Status.NotImplemented;

--- a/source/GurkaSpec/Feature.cs
+++ b/source/GurkaSpec/Feature.cs
@@ -14,32 +14,7 @@ public class Feature
 
     public List<string> Tags { get; set; } = new List<string>();
 
-    public Status Status
-    {
-        get
-        {
-            if (Tags.Contains("@ignore"))
-            {
-                return Status.NotImplemented;
-            }
-
-            if (Scenarios.Any(scenario => scenario.Status == Status.Failed) ||
-                (Background != null && Background.Status == Status.Failed) ||
-                Rules.Any(rule => rule.Status == Status.Failed))
-            {
-                return Status.Failed;
-            }
-
-            if (Scenarios.Any(scenario => scenario.Status == Status.Passed) ||
-                Rules.Any(rule => rule.Status == Status.Passed))
-            {
-                return Status.Passed;
-            }
-
-            return Status.NotImplemented;
-        }
-        set { }
-    }
+    public Status Status { get; set; }
 
     public string? Description { get; set; }
     public Background? Background { get; set; }

--- a/source/GurkaSpec/Rule.cs
+++ b/source/GurkaSpec/Rule.cs
@@ -13,6 +13,11 @@ public class Rule
     {
         get
         {
+            if (Tags.Contains("@ignore"))
+            {
+                return Status.NotImplemented;
+            }
+
             if (Scenarios.All(scenario => scenario.Status == Status.Passed) &&
                 (Background == null || Background.Status == Status.Passed))
             {

--- a/source/GurkaSpec/Rule.cs
+++ b/source/GurkaSpec/Rule.cs
@@ -9,31 +9,7 @@ public class Rule
     public Background? Background { get; set; }
     public List<string> Tags { get; set; } = new List<string>();
 
-    public Status Status
-    {
-        get
-        {
-            if (Tags.Contains("@ignore"))
-            {
-                return Status.NotImplemented;
-            }
-
-            if (Scenarios.All(scenario => scenario.Status == Status.Passed) &&
-                (Background == null || Background.Status == Status.Passed))
-            {
-                return Status.Passed;
-            }
-
-            if (Scenarios.Any(scenario => scenario.Status == Status.Failed) ||
-                (Background != null && Background.Status == Status.Failed))
-            {
-                return Status.Failed;
-            }
-
-            return Status.NotImplemented;
-        }
-        set { }
-    }
+    public Status Status { get; set; }
 
     private TimeSpan _testDuration;
     public string TestDuration

--- a/source/GurkaSpec/Scenario.cs
+++ b/source/GurkaSpec/Scenario.cs
@@ -7,6 +7,7 @@ public class Scenario
     public string? Examples { get; set; }
     public List<string> Tags { get; set; } = new List<string>();
     public bool IsOutline { get; set; } = false;
+    public bool IsOutlineChild { get; set; } = false;
 
     public Status Status
     {

--- a/source/GurkaSpec/Scenario.cs
+++ b/source/GurkaSpec/Scenario.cs
@@ -9,34 +9,7 @@ public class Scenario
     public bool IsOutline { get; set; } = false;
     public bool IsOutlineChild { get; set; } = false;
 
-    public Status Status
-    {
-        get
-        {
-            if (Tags.Contains("@ignore"))
-            {
-                return Status.NotImplemented;
-            }
-
-            if (Steps.Any(step => step.Status == Status.Failed))
-            {
-                return Status.Failed;
-            }
-
-            if (Steps.Any(step => step.Status == Status.NotImplemented))
-            {
-                return Status.NotImplemented;
-            }
-
-            if (Steps.All(step => step.Status == Status.Passed))
-            {
-                return Status.Passed;
-            }
-
-            return Status.NotImplemented;
-        }
-        set { }
-    }
+    public Status Status { get; set; }
 
     private TimeSpan _testDuration;
     public string TestDuration

--- a/source/GurkaSpec/Scenario.cs
+++ b/source/GurkaSpec/Scenario.cs
@@ -6,11 +6,22 @@ public class Scenario
     public string? Description { get; set; }
     public string? Examples { get; set; }
     public List<string> Tags { get; set; } = new List<string>();
+    public bool IsOutline { get; set; } = false;
 
     public Status Status
     {
         get
         {
+            if (Tags.Contains("@ignore"))
+            {
+                return Status.NotImplemented;
+            }
+
+            if (Steps.Any(step => step.Status == Status.Failed))
+            {
+                return Status.Failed;
+            }
+
             if (Steps.Any(step => step.Status == Status.NotImplemented))
             {
                 return Status.NotImplemented;
@@ -21,7 +32,7 @@ public class Scenario
                 return Status.Passed;
             }
 
-            return Status.Failed;
+            return Status.NotImplemented;
         }
         set { }
     }

--- a/source/VizGurka/Pages/Features/Features.cshtml.cs
+++ b/source/VizGurka/Pages/Features/Features.cshtml.cs
@@ -98,7 +98,7 @@ public class FeaturesModel : PageModel
         FeatureFailedCount = Features.Count(f => f.Status.ToString() == "Failed");
         FeatureNotImplementedCount = Features.Count(f => f.Status.ToString() == "NotImplemented");
     }
-    
+
     private void PopulateFeatures(SpecGurka.GurkaSpec.Product product)
     {
         Features = product.Features.Select(f => new Feature
@@ -156,7 +156,7 @@ public class FeaturesModel : PageModel
                 {
                     FeatureTree["Features"] = new List<Feature>();
                 }
-                
+
                 ((List<Feature>)FeatureTree["Features"]).Add(feature);
             }
             else
@@ -282,11 +282,27 @@ public class FeaturesModel : PageModel
             .Take(10) // Show 10 slowest scenarios
             .ToList();
     }
-    
+
     public IHtmlContent MarkdownStringToHtml(string input)
     {
-        var trimmedInput = input.Trim();
+        if (string.IsNullOrEmpty(input))
+        {
+            return HtmlString.Empty;
+        }
+
+        // Split the input into lines
+        var lines = input.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+        // Trim leading whitespace from each line
+        for (int i = 0; i < lines.Length; i++)
+        {
+            lines[i] = lines[i].TrimStart();
+        }
+
+        // Join the lines back together
+        var trimmedInput = string.Join(Environment.NewLine, lines);
+
+        // Convert to HTML
         return new HtmlString(Markdown.ToHtml(trimmedInput, Pipeline));
     }
-
 }

--- a/tests/OWASP.Spec/Features/HttpRequestHeaderValidation/HttpRequestHeaderValidation.feature
+++ b/tests/OWASP.Spec/Features/HttpRequestHeaderValidation/HttpRequestHeaderValidation.feature
@@ -1,0 +1,126 @@
+# language: sv
+
+# OWASP V14.5 HTTP Request Header Validation
+@L1
+@L2
+@L3
+@ejkomplett
+Egenskap: HTTP Request Header Validation
+
+    HTTP Request Header Validation (HTTP-begäranshuvudvalidering) är en kritisk säkerhetsåtgärd i OWASP Application Security Verification Standard (ASVS) (se punkt [V14.5](https://github.com/OWASP/ASVS/blob/v4.0.3/4.0/en/0x22-V14-Config.md#v145-http-request-header-validation)) 
+    eftersom HTTP-huvuden används för att styra och hantera kommunikationen mellan klienter och servrar. Om dessa huvuden inte kontrolleras ordentligt kan en applikation bli sårbar för 
+    flera typer av attacker som kan leda till dataintrång, sessionkapning eller systemexploatering.
+    
+    HTTP Request Header Validation innebär att webbapplikationen kontrollerar att informationen i inkommande förfrågningar är korrekt och säker. Detta hjälper till att förhindra 
+    attacker där angripare försöker skicka skadliga eller manipulerade uppgifter, såsom förfalskade identiteter eller otillåtna kommandon. Genom att validera dessa uppgifter kan vi skydda användarnas 
+    data och säkerställa att endast legitima förfrågningar behandlas.
+
+    HTTP Request Header Validation innebär att applikationen (kan vara och bör vara båda på webbserver och applikations nivå) granskar och filtrerar inkommande HTTP-huvuden (headers) för att säkerställa att de 
+    följer förväntade format och värden. Detta inkluderar kontroll av obligatoriska huvuden, begränsning av okända eller oväntade huvuden samt verifiering av värden för att motverka angrepp som HTTP 
+    smuggling, host header poisoning och header injection. Genom att strikt validera och normalisera inkommande HTTP-huvuden kan applikationen förhindra otillbörlig åtkomst, manipulering av sessionsdata 
+    och andra säkerhetsrisker relaterade till felaktigt hanterade HTTP-begäranden.
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.5.1 - Verifiera att applikationsservern endast accepterar giltiga HTTP-metoder.
+        Verifiera att applikationsservern endast accepterar de HTTP-metoder som används av
+        applikationen/API:et, inklusive pre-flight OPTIONS-förfrågningar, och loggar/varnar
+        vid förfrågningar som inte är giltiga för applikationens kontext.
+        
+        Läs mer om HTTP-metoder på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera att endast giltiga HTTP-metoder accepteras för endpoints
+            När jag skickar en "<metod>"-förfrågan till "<path>"
+            Så  ska svaret ha statuskoden "<förväntad_status>"
+            Och om metoden är ogiltig ska svaret innehålla headern "Allow" med de tillåtna metoderna
+            Och om metoden är OPTIONS ska svaret innehålla CORS-headers för tillåtna metoder
+
+            # Och   om metoden är ogiltig ska en säkerhetsvarning registreras i systemloggen
+            # Och   om metoden är ogiltig ska loggposten innehålla information om förfrågningen
+            # Ett krav är att applikationen ska logga varningar vid ogiltiga förfrågningar
+            # Detta krav är inte implementerat i detta exempel då det kräver att testprojektet
+            # har tillgång till systemloggen.
+            Exempel:
+                | metod   | path              | förväntad_status | kommentar           |
+                | GET     | /api/core/persons | 200              | Giltig metod        |
+                | POST    | /api/core/persons | 400              | Felaktig begäran    |
+                | PUT     | /api/core/persons | 405              | Ogiltig metod       |
+                | DELETE  | /api/core/persons | 405              | Ogiltig metod       |
+                | OPTIONS | /api/core/persons | 405              | Ogiltig metod       |
+                | PATCH   | /api/core/persons | 405              | Ogiltig metod       |
+                | HEAD    | /api/core/persons | 405              | Ogiltig metod       |
+                | TRACE   | /api/core/persons | 405              | Ogiltig metod       |
+                | INVALID | /api/core/persons | 405              | Okänd/ogiltig metod |
+
+    @ignore
+    @L1
+    @L2
+    @L3
+    # Detta scenario är ignorerat då det kräver att testprojektet har tillgång till serverkoden.
+    # Att göra blackbox tester för detta kommer inte vara givande på något sätt.
+    Regel: OWASP 14.5.2 - Verifiera att Origin-headern inte används för autentisering eller åtkomstkontroll
+        Verifiera att den angivna Origin-headern inte används för autentisering eller
+        åtkomstkontrollbeslut, eftersom Origin-headern enkelt kan ändras av en
+        angripare.
+        
+        Läs mer om Origin-headern:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.5.3 - Verifiera att CORS-header använder strikt lista med betrodda domäner
+        Verifiera att Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header
+        använder en strikt vitlista av betrodda domäner och underdomäner för att matcha mot
+        och inte stödjer ursprunget "null".
+        
+        Läs mer om CORS och Access-Control-Allow-Origin:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
+
+        @L1
+        @L2
+        @L3
+        # Detta scenario antar att localhost:3002 är en betrodd domän
+        Abstrakt Scenario: Verifiera att CORS-headers hanteras korrekt för cross-origin requests
+            När jag skickar en "<metod>" förfrågan till "<path>" med Origin-header "<origin>"
+            Så  om origin är betrodd ska svaret innehålla korrekt Access-Control-Allow-Origin header
+            Och om origin är obetrodd ska svaret inte innehålla Access-Control-Allow-Origin header
+            Och svarshuvudet Access-Control-Allow-Origin ska aldrig innehålla värdet "*" eller "null"
+
+            Exempel:
+                | metod | path              | origin                     |
+                | GET   | /api/core/persons | https://localhost:3002     |
+                | GET   | /api/core/persons | https://untrusted-site.com |
+                | GET   | /api/core/persons | null                       |
+
+    @ignore
+    @L2
+    @L3
+    # Detta scenario är ignorerat då det kräver att testprojektet kan hämta en giltig bearer token
+    # att skicka med i testets förfrågningar.
+    # Testprojektet behöver även tillgång till serverkoden för att kontrollera säkerhetsloggen.
+    Regel: OWASP 14.5.4 - Verifiera att HTTP-headers från betrodda proxys och SSO-enheter valideras
+        Verifiera att HTTP-headers som läggs till av betrodda proxys eller SSO-enheter, såsom
+        bearer tokens, valideras och autentiseras av applikationen för att förhindra
+        identitetsförfalskning och session hijacking.
+        
+        Läs mer om HTTP-autentisering och säkerhet:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
+        [Link](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera att HTTP-headers från betrodda proxys och SSO-enheter valideras korrekt
+            När jag skickar en "<metod>"-förfrågan till "<path>" med headern "<header>" som innehåller värdet "<värde>"
+            Så  ska applikationen validera headers korrekt
+            Och om headern är ogiltig eller manipulerad ska autentiseringen misslyckas
+            Och om en ogiltig header detekteras ska en säkerhetslogg skapas
+
+            Exempel:
+                | metod | path | header | värde |
+                | metod | path | header | värde |

--- a/tests/OWASP.Spec/Features/HttpSecurityHeaders/HttpSecurityHeaders.feature
+++ b/tests/OWASP.Spec/Features/HttpSecurityHeaders/HttpSecurityHeaders.feature
@@ -1,0 +1,195 @@
+# language: sv
+
+# OWASP V14.4 HTTP Security Headers
+@L1
+@L2
+@L3
+@ejkomplett
+Egenskap: Http Security Headers
+    Som en säkerhetstestare vill jag verifiera att applikationen använder lämpliga HTTP-säkerhetsrubriker
+    för att förhindra attacker som t.ex. Cross-Site Scripting (XSS).
+    
+    Läs mer om OWASP Application Security Verification Standard 4.0.3 - V14.4:
+    [Link](https://owasp.org/www-project-application-security-verification-standard/)
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.1 - Verifiera att varje HTTP-svar innehåller en Content-Type-header.
+        Specificera även en säker teckenuppsättning (t.ex. UTF-8, ISO-8859-1) om innehållstypen är text/*, /+xml och
+        application/xml. Innehållet måste matcha den angivna Content-Type-rubriken.
+        
+        Läs mer om Content-Type-headers på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera teckenuppsättning för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en Content-Type-rubrik med innehållstyp "<innehållstyp>"
+            Och om innehållstypen är av texttyp ska den innehålla en säker teckenuppsättning
+
+            Exempel:
+                | path                           | innehållstyp     |
+                | /api/core/persons              | application/json |
+                | /api/core/persons/ext/10000043 | application/json |
+
+    @Ignore
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.2 - Verifiera att alla API-svar innehåller en Content-Disposition-header.
+        Content-Disposition ska vara satt till "attachment" med ett lämpligt filnamn för innehållstypen.
+        Relevant vid endpoints som returnerar filer som ska laddas ner.
+        
+        Läs mer om Content-Disposition-headers på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera Content-Disposition med lämpligt filnamn
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en Content-Disposition-rubrik
+            Och Content-Disposition-rubriken ska vara satt till "attachment"
+            Och Content-Disposition-rubriken ska innehålla ett lämpligt filnamn för innehållstypen "<innehållstyp>"
+
+            Exempel:
+                | path                       | innehållstyp     |
+                | /api/core/path/to/download | application/json |
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.3 - Verifiera att en Content Security Policy (CSP) header finns på plats.
+        CSP-headern ska hjälpa till att minska påverkan från XSS-attacker som HTML, DOM, JSON och JavaScript-injiceringar.
+        
+        Läs mer om Content Security Policy på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera CSP-skydd för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en Content-Security-Policy-rubrik
+            Och ska svaret innehålla en Content-Type-rubrik med innehållstyp "<innehållstyp>"
+            Och ska CSP-rubriken innehålla restriktioner för "script-src"
+            Och ska CSP-rubriken innehålla restriktioner för "style-src"
+            Och ska CSP-rubriken inte innehålla "unsafe-inline" för script
+            Och ska CSP-rubriken inte innehålla "unsafe-eval" för script
+            Och ska CSP-rubriken innehålla en rapporteringsmekanism
+            Och ska minst ett av följande vara sant i CSP-rubriken för script:
+                | alternativ                |
+                | Innehåller nonce-värden   |
+                | Innehåller hash-värden    |
+                | Inga unsafe-inline-värden |
+
+            Exempel:
+                | path              | innehållstyp     |
+                | /api/core/persons | application/json |
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.4 - Verifiera att alla svar innehåller en X-Content-Type-Options: nosniff header.
+        X-Content-Type-Options förhindrar webbläsare från MIME-sniffing vilket kan leda till säkerhetsproblem.
+        
+        Läs mer om X-Content-Type-Options på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera X-Content-Type-Options för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en X-Content-Type-Options-rubrik
+            Och X-Content-Type-Options-rubriken ska vara satt till "nosniff"
+            Och ska svaret innehålla en Content-Type-rubrik med innehållstyp "<innehållstyp>"
+
+            Exempel:
+                | path              | innehållstyp     |
+                | /api/core/persons | application/json |
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.5 - Verifiera att en Strict-Transport-Security (HSTS) header finns på alla svar.
+        HSTS-headern ska inkludera max-age med tillräcklig varaktighet och includeSubdomains för alla underdomäner.
+        
+        Läs mer om Strict-Transport-Security på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera Strict-Transport-Security för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en Strict-Transport-Security-rubrik
+            Och Strict-Transport-Security-rubriken ska innehålla "max-age" med värde minst 15724800
+            Och Strict-Transport-Security-rubriken ska inkludera "includeSubdomains"
+            Och ska svaret innehålla en Content-Type-rubrik med innehållstyp "<innehållstyp>"
+            Och ska Strict-Transport-Security-rubriken inkludera "preload"
+
+            Exempel:
+                | path              | innehållstyp     |
+                | /api/core/persons | application/json |
+
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.6 - Verifiera att en lämplig Referrer-Policy header är inkluderad.
+        Referrer-Policy förhindrar att känslig information i URL:er exponeras via Referer-headern till otillförlitliga parter.
+        
+        Läs mer om Referrer-Policy på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera Referrer-Policy för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en Referrer-Policy-rubrik
+            Och Referrer-Policy-rubriken ska ha något av följande säkra värden:
+                | no-referrer                     |
+                | no-referrer-when-downgrade      |
+                | same-origin                     |
+                | strict-origin                   |
+                | strict-origin-when-cross-origin |
+                | origin-when-cross-origin        |
+            Och Referrer-Policy-rubriken ska inte innehålla något av följande osäkra värden:
+                | unsafe-url |
+                | origin     |
+
+            Exempel:
+                | path              |
+                | /api/core/persons |
+
+    @ignore
+    @L1
+    @L2
+    @L3
+    Regel: OWASP 14.4.7 - Verifiera att innehållet i webbapplikationen inte kan bäddas in i tredjepartssidor som standard.
+        Inbäddning av specifika resurser bör endast tillåtas där det är nödvändigt genom lämpliga Content-Security-Policy: frame-ancestors och X-Frame-Options rubriker.
+        
+        Läs mer om X-Frame-Options på MDN:
+        [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
+
+        @L1
+        @L2
+        @L3
+        Abstrakt Scenario: Verifiera clickjacking-skydd för olika innehållstyper
+            När jag skickar en GET-förfrågan till "<path>"
+            Så  ska svaret innehålla en X-Frame-Options-rubrik
+            Och X-Frame-Options-rubriken ska ha ett av följande säkra värden:
+                | säkert värde |
+                | DENY         |
+                | SAMEORIGIN   |
+            Och ska svaret innehålla en Content-Type-rubrik med innehållstyp "<innehållstyp>"
+            Och ska CSP-rubriken innehålla direktivet "frame-ancestors"
+            Och ska CSP-direktivet "frame-ancestors" ha ett restriktivt värde som matchar X-Frame-Options
+
+            Exempel:
+                | path            | innehållstyp               |
+                | /path/to/iframe | image, text/html, text/xml |

--- a/tests/OWASP.Spec/Features/HttpSecurityHeaders/HttpSecurityHeaders.feature
+++ b/tests/OWASP.Spec/Features/HttpSecurityHeaders/HttpSecurityHeaders.feature
@@ -35,7 +35,7 @@ Egenskap: Http Security Headers
                 | /api/core/persons              | application/json |
                 | /api/core/persons/ext/10000043 | application/json |
 
-    @Ignore
+    @ignore
     @L1
     @L2
     @L3


### PR DESCRIPTION
This pull request introduces significant enhancements to the handling of scenario outlines and status propagation in the `GenGurka` project. The most important changes include the addition of new helper methods and extensions, the expansion of scenario outlines into individual scenarios, and improvements to status and duration calculations.

Enhancements to scenario outlines and status propagation:

* [`source/GenGurka/Extensions/GherkinDocumentExtensions.cs`](diffhunk://#diff-da1fb00631c9d7b88c7372b0ac3279e7f2f232eb5a8016fe9ea3e7870fb650a4R34-R54): Added new helper methods to expand scenario outlines into individual scenarios and improved status propagation by replacing `SetFeatureStatusToNotImplemented` with `StatusPropagationHelper.MarkIgnoredItemsStatus`. [[1]](diffhunk://#diff-da1fb00631c9d7b88c7372b0ac3279e7f2f232eb5a8016fe9ea3e7870fb650a4R34-R54) [[2]](diffhunk://#diff-da1fb00631c9d7b88c7372b0ac3279e7f2f232eb5a8016fe9ea3e7870fb650a4L50-R69) [[3]](diffhunk://#diff-da1fb00631c9d7b88c7372b0ac3279e7f2f232eb5a8016fe9ea3e7870fb650a4R97-R162) [[4]](diffhunk://#diff-da1fb00631c9d7b88c7372b0ac3279e7f2f232eb5a8016fe9ea3e7870fb650a4R180-R247)
* [`source/GenGurka/Extensions/ScenarioOutlineExtensions.cs`](diffhunk://#diff-290194125f7bec7e7ace00c35eaf81e9f3e97cec2e6eff50160119ae821ec35dR1-R155): Introduced the `ScenarioOutlineExtensions` class with methods to process scenarios, including handling scenario outlines and their instances, and calculating aggregate durations.

Improvements to test result matching and status application:

* [`source/GenGurka/Extensions/TestRunExtensions.cs`](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256R2): Enhanced the `MatchWithGurkaFeatures` method to utilize `ScenarioOutlineExtensions` for processing scenarios and added a new method `FindMatchingTestResult` to improve test result matching. [[1]](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256R2) [[2]](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256L21-R22) [[3]](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256L40-R54) [[4]](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256L59-R164) [[5]](diffhunk://#diff-ddfb7289b04e720abd425c4b38ea026936b3d0ec657d3deee841164e723b2256L145-R195)

Scenarios now have IsOutline and IsOutlineChild bool properties. This is because a scenario outline is handled as scenario and needs an identifier. If the Scenario is the Scenario Outline Template, IsOutline = True. If the Scenario is one of the Scenario Outline Example runs: IsOutlineChild = True.
![image](https://github.com/user-attachments/assets/04342231-4511-4232-9bbd-ecc0c4307d09)
