### PR TITLE
Refactor PowerShell script with cross-platform support and improved logging

### DIFF
--- a/source/VizGurka/Helpers/TestrunReader.cs
+++ b/source/VizGurka/Helpers/TestrunReader.cs
@@ -93,6 +93,19 @@ public static class TestrunReader
     public static Testrun? ReadLatestRun(string productName)
     {
         string directoryPath = _configuration["Path:directoryPath"];
+
+        if (!Directory.Exists(directoryPath))
+        {
+            try
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Failed to create directory: {ex.Message}");
+            }
+        }
+
         string[] filePaths = Directory.GetFiles(directoryPath);
 
         Testrun? latestTestrun = null;


### PR DESCRIPTION

This pull request includes several updates to improve error handling, logging, and cross-platform compatibility in the `VizGurka` project. The most important changes include adding directory creation and error handling, enhancing PowerShell script logging, and improving cross-platform compatibility.

The script has been successfully ran in a Docker Container.

Error handling improvements:

* [`source/VizGurka/Helpers/TestrunReader.cs`](diffhunk://#diff-0d6e5f2d9f661f70d5bc2802c772cb878f73cc2897bae01495ce4f8e48e1096cR96-R108): Added a check to create the directory if it does not exist and handle potential exceptions.

Logging enhancements:

* [`source/VizGurka/Services/PowerShellService.cs`](diffhunk://#diff-f9a55f0c6af9933d62991222e7f6182f4a3a17f032dbbdd00f1ec97a48cf6e86L49-R49): Added verbose logging to the PowerShell script execution and logged each output line and errors. [[1]](diffhunk://#diff-f9a55f0c6af9933d62991222e7f6182f4a3a17f032dbbdd00f1ec97a48cf6e86L49-R49) [[2]](diffhunk://#diff-f9a55f0c6af9933d62991222e7f6182f4a3a17f032dbbdd00f1ec97a48cf6e86R68-R78) [[3]](diffhunk://#diff-f9a55f0c6af9933d62991222e7f6182f4a3a17f032dbbdd00f1ec97a48cf6e86R99-R100)

Cross-platform compatibility:

* [`source/VizGurka/fetch_github_artifacts.ps1`](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L2-R34): Added checks for PowerShell version and platform to handle path separators and use appropriate commands for different operating systems. [[1]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L2-R34) [[2]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L58-R80) [[3]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L143-R165) [[4]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L180-R201) [[5]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L247-R268) [[6]](diffhunk://#diff-27f6e7cf53d58a7ee5cbc25860261781a8808c3044c4dfcc438af4ab0abc7dc9L262-R296)