### PR TITLE
add trace to which file failed to read

### DIFF
--- a/source/GenGurka/Helpers/GherkinFileReader.cs
+++ b/source/GenGurka/Helpers/GherkinFileReader.cs
@@ -18,13 +18,13 @@ public static class GherkinFileReader
         catch
         {
             //UI.PrintError("The gherkin file could not be read.");
-            throw new UnableToReadFileException("The file could not be read.");
+            throw new UnableToReadFileException($"The file {path} could not be read.");
         }
 
         if (gherkinDoc.Feature == null)
         {
             // UI.PrintError("The gherkin file could not be read.");
-            throw new UnableToReadFileException("The file could not be read.");
+            throw new UnableToReadFileException($"The file {path} could not be read.");
         }
         return gherkinDoc;
     }


### PR DESCRIPTION
* [`source/GenGurka/Helpers/GherkinFileReader.cs`](diffhunk://#diff-0e2e217ce4a73f6040f98971118945b6161de40e77ef067dfba9907ebc1e791fL21-R27): Updated the `UnableToReadFileException` messages to include the `path` of the file that could not be read.